### PR TITLE
Support for stdout and stderr redirection

### DIFF
--- a/configs/supervisord.conf
+++ b/configs/supervisord.conf
@@ -26,6 +26,28 @@ redirect_stderr=true
 stdout_logfile=/dev/stdout
 stdout_logfile_maxbytes=0
 
+[program:php-fpm-logging-stdout]
+command=/bin/sh -c "exec 3<>/var/log/php{{php_version}}/stdout; cat <&3 >/proc/1/fd/1"
+process_name=%(program_name)s_%(process_num)02d
+numprocs=1
+autostart=true
+autorestart=false
+startsecs=0
+redirect_stderr=true
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0
+
+[program:php-fpm-logging-stderr]
+command=/bin/sh -c "exec 4<>/var/log/php{{php_version}}/stderr; cat <&4 >/proc/1/fd/2"
+process_name=%(program_name)s_%(process_num)02d
+numprocs=1
+autostart=true
+autorestart=false
+startsecs=0
+redirect_stderr=true
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0
+
 [eventlistener:supervisord-watchdog]
 command=/sbin/supervisord-watchdog
 events=PROCESS_STATE_FATAL

--- a/php56.dockerfile
+++ b/php56.dockerfile
@@ -48,6 +48,9 @@ COPY configs/php-fpm.conf ${PHP_CONFIG_DIR}/php-fpm.conf
 RUN sed -i "s|{{php_version}}|${PHP_VERSION}|g" ${PHP_CONFIG_DIR}/php-fpm.conf
 COPY configs/php.www.conf ${PHP_CONFIG_DIR}/php-fpm.d/www.conf
 
+RUN mkfifo -m 666 /var/log/php${PHP_VERSION}/stdout && \
+    mkfifo -m 666 /var/log/php${PHP_VERSION}/stderr
+
 # Configure file uploads
 RUN chown -R nginx:www /var/tmp/nginx && \
     chmod 770 /var/tmp/nginx && \

--- a/php71.dockerfile
+++ b/php71.dockerfile
@@ -47,6 +47,10 @@ COPY configs/php-fpm.conf ${PHP_CONFIG_DIR}/php-fpm.conf
 RUN sed -i "s|{{php_version}}|${PHP_VERSION}|g" ${PHP_CONFIG_DIR}/php-fpm.conf
 COPY configs/php.www.conf ${PHP_CONFIG_DIR}/php-fpm.d/www.conf
 
+# Configure PHP-FPM logging
+RUN mkfifo -m 666 /var/log/php${PHP_VERSION}/stdout && \
+    mkfifo -m 666 /var/log/php${PHP_VERSION}/stderr
+
 # Configure file uploads
 RUN chown -R nginx:www /var/tmp/nginx && \
     chmod 770 /var/tmp/nginx && \

--- a/php72.dockerfile
+++ b/php72.dockerfile
@@ -47,6 +47,10 @@ COPY configs/php-fpm.conf ${PHP_CONFIG_DIR}/php-fpm.conf
 RUN sed -i "s|{{php_version}}|${PHP_VERSION}|g" ${PHP_CONFIG_DIR}/php-fpm.conf
 COPY configs/php.www.conf ${PHP_CONFIG_DIR}/php-fpm.d/www.conf
 
+# Configure PHP-FPM logging
+RUN mkfifo -m 666 /var/log/php${PHP_VERSION}/stdout && \
+    mkfifo -m 666 /var/log/php${PHP_VERSION}/stderr
+
 # Configure file uploads
 RUN chown -R nginx:www /var/tmp/nginx && \
     chmod 770 /var/tmp/nginx && \


### PR DESCRIPTION
This PR is aimed to solve the issue where PHP-FPM child processes cannot write to `stdout` and `stderr` properly. Docker logs will only show the output from the process with a `pid` of `1`; the main command run on the container. In our case, this is the `entrypoint.sh` script. PHP-FPM child processes do not bubble up the `stdout` and `stderr` to the proper process so that the output is caught. 

Output for the Docker container is caught at `/proc/1/fd/1` and `/proc/1/fd/2`. These are the locations for `stdout` and `stderr` respectively on process `1`. The PHP child processes cannot write to these directly as it will throw an error regarding permissions, so we can use a bit of stream redirection trickery to get this to work.

First, we create the stream files to which we can send logs. This is done in `php71.dockerfile`, and `php72.dockerfile`. We're creating a file for `stdout` and `stderr` individually.

```
RUN mkfifo -m 666 /var/log/php${PHP_VERSION}/stdout && \
    mkfifo -m 666 /var/log/php${PHP_VERSION}/stderr
```

Once these files are present, we can redirect anything that gets sent to these files to a custom file descriptor. Setting the file descriptor for `stdout` to `3`, and the descriptor for `stderr` to `4`. File descriptors `0`, `1`, and `2` are reserved for `stdin`, `stdout` and `stderr`.

```bash
exec 3<>/var/log/php{{php_version}}/stdout;
exec 4<>/var/log/php{{php_version}}/stderr;
```
This will take everything that is written to the custom `stdout` and `stderr` files and redirect it to the file descriptors referenced.

Now that we have the input from the stream files being redirected to a file descriptor, we need a way to catch this output and forward it to the container's `stdout` and `stderr`. We can use `cat` for that.

```bash
cat <&3>/proc/1/fd/1
cat <&4>/proc/1/fd/2
```

What this will do is grab the output of the custom file descriptor, and then redirect that output to the main process' `stdout` and `stderr` stream. When these commands are run however, they stay active in the foreground. It's also important to note that they **MUST** stay active for the output to get redirected properly. If we throw it in the background by appending a `&`, the process could fail and the output would no longer get redirected. 

This is where Supervisor comes in handy. We can set this up to run as a Supervisor process so that the failures can be caught, and the redirection can be restarted.

```
[program:php-fpm-logging-stdout]
command=/bin/sh -c "exec 3<>/var/log/php{{php_version}}/stdout; cat <&3 >/proc/1/fd/1"
process_name=%(program_name)s_%(process_num)02d
numprocs=1
autostart=true
autorestart=false
startsecs=0
redirect_stderr=true
stdout_logfile=/dev/stdout
stdout_logfile_maxbytes=0

[program:php-fpm-logging-stderr]
command=/bin/sh -c "exec 4<>/var/log/php{{php_version}}/stderr; cat <&4 >/proc/1/fd/2"
process_name=%(program_name)s_%(process_num)02d
numprocs=1
autostart=true
autorestart=false
startsecs=0
redirect_stderr=true
stdout_logfile=/dev/stdout
stdout_logfile_maxbytes=0
```
Using this setup, we can specify logs in PHP to be written to the custom stream files without permission issues popping up. Here's an example of how we could set it up with Monolog in a Laravel project.

```php
// config/logging.php

'channels' => [
    'stdout' => [
        'driver' => 'monolog',
        'handler' => StreamHandler::class,
        'with' => [
            'stream' => '/var/log/php7/stdout',
        ],
    ],

    'stderr' => [
        'driver' => 'monolog',
        'handler' => StreamHandler::class,
        'with' => [
            'stream' => '/var/log/php7/stderr',
        ],
    ],
],
```
Here's an example of the output from the Docker logs when we log something in a project.

```
No secrets.
2018-11-09 15:53:48,909 CRIT Set uid to user 0
2018-11-09 15:53:48,915 INFO supervisord started with pid 10
2018-11-09 15:53:49,919 INFO spawned: 'supervisord-watchdog' with pid 13
2018-11-09 15:53:49,921 INFO spawned: 'nginx_00' with pid 14
2018-11-09 15:53:49,923 INFO spawned: 'php-fpm_00' with pid 15
2018-11-09 15:53:49,925 INFO spawned: 'php-fpm-logging-stderr_00' with pid 16
2018-11-09 15:53:49,928 INFO spawned: 'php-fpm-logging-stdout_00' with pid 17
[09-Nov-2018 15:53:49] NOTICE: fpm is running, pid 15
2018-11-09 15:53:49,950 INFO success: nginx_00 entered RUNNING state, process has stayed up for > than 0 seconds (startsecs)
2018-11-09 15:53:49,950 INFO success: php-fpm_00 entered RUNNING state, process has stayed up for > than 0 seconds (startsecs)
2018-11-09 15:53:49,950 INFO success: php-fpm-logging-stderr_00 entered RUNNING state, process has stayed up for > than 0 seconds (startsecs)
2018-11-09 15:53:49,951 INFO success: php-fpm-logging-stdout_00 entered RUNNING state, process has stayed up for > than 0 seconds (startsecs)
[09-Nov-2018 15:53:49] NOTICE: ready to handle connections
2018-11-09 15:53:50,967 INFO success: supervisord-watchdog entered RUNNING state, process has stayed up for > than 1 seconds (startsecs)
[2018-11-09 10:54:18] local.DEBUG: This message is to demonstrate the 'debug' level log entry.
[2018-11-09 10:54:18] local.INFO: This message is to demonstrate the 'info' level log entry.
[2018-11-09 10:54:18] local.ERROR: This message is to demonstrate the 'error' level log entry.
[2018-11-09 10:54:18] local.WARNING: This message is to demonstrate the 'warning' level log entry.
[2018-11-09 10:54:18] local.INFO: Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum. Donec elementum ligula eu sapien consequat eleifend. Donec nec dolor erat, condimentum sagittis sem. Praesent porttitor porttitor risus, dapibus rutrum ipsum gravida et. Integer lectus nisi, facilisis sit amet eleifend nec, pharetra ut augue. Integer quam nunc, consequat nec egestas ac, volutpat ac nisi. Sed consectetur dignissim dignissim. Donec pretium est sit amet ipsum fringilla feugiat. Aliquam erat volutpat. Maecenas scelerisque, orci sit amet cursus tincidunt, libero nisl eleifend tortor, vitae cursus risus mauris vitae nisi. Cras laoreet ultrices ligula eget tempus. Aenean metus purus, iaculis ut imperdiet eget, sodales et massa. Duis pellentesque nisl vel massa dapibus non lacinia velit volutpat. Maecenas accumsan interdum sodales. In hac habitasse platea dictumst. Pellentesque ornare blandit orci, eget tristique risus convallis ut. Vivamus a sapien neque. Morbi malesuada massa ac sapien luctus vulputate. Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum. Donec elementum ligula eu sapien consequat eleifend. Donec nec dolor erat, condimentum sagittis sem. Praesent porttitor porttitor risus, dapibus rutrum ipsum gravida et. Integer lectus nisi, facilisis sit amet eleifend nec, pharetra ut augue. Integer quam nunc, consequat nec egestas ac, volutpat ac nisi. Sed consectetur dignissim dignissim. Donec pretium est sit amet ipsum fringilla feugiat. Aliquam erat volutpat. Maecenas scelerisque, orci sit amet cursus tincidunt, libero nisl eleifend tortor, vitae cursus risus mauris vitae nisi. Cras laoreet ultrices ligula eget tempus. Aenean metus purus, iaculis ut imperdiet eget, sodales et massa. Duis pellentesque nisl vel massa dapibus non lacinia velit volutpat. Maecenas accumsan interdum sodales. In hac habitasse platea dictumst. Pellentesque ornare blandit orci, eget tristique risus convallis ut. Vivamus a sapien neque. Morbi malesuada massa ac sapien luctus vulputate. Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum. Donec elementum ligula eu sapien consequat eleifend. Donec nec dolor erat, condimentum sagittis sem. Praesent porttitor porttitor risus, dapibus rutrum ipsum gravida et. Integer lectus nisi, facilisis sit amet eleifend nec, pharetra ut augue. Integer quam nunc, consequat nec egestas ac, volutpat ac nisi. Sed consectetur dignissim dignissim. Donec pretium est sit amet ipsum fringilla feugiat. Aliquam erat volutpat. Maecenas scelerisque, orci sit amet cursus tincidunt, libero nisl eleifend tortor, vitae cursus risus mauris vitae nisi. Cras laoreet ultrices ligula eget tempus. Aenean metus purus, iaculis ut imperdiet eget, sodales et massa. Duis pellentesque nisl vel massa dapibus non lacinia velit volutpat. Maecenas accumsan interdum sodales. In hac habitasse platea dictumst. Pellentesque ornare blandit orci, eget tristique risus convallis ut. Vivamus a sapien neque. Morbi malesuada massa ac sapien luctus vulputate.
127.0.0.1 -  09/Nov/2018:15:54:17 +0000 "GET /index.php" 200
172.28.0.2 - - [09/Nov/2018:15:54:18 +0000] "GET /api/test HTTP/1.1" 200 15840 "-" "PostmanRuntime/7.3.0" "172.28.0.1"
```

As you can see, it logs all of the messages without the `warning:` prefix that PHP-FPM provides when catching the worker's output. It logs long messages without truncating the output.

This should hold us over until PHP 7.3 drops and it will also allow the applications running on 7.1 and 7.2 to take advantage of using Docker for logging.