### PR TITLE
remove copy directive for export_secrets.sh, this corrects build failure

### DIFF
--- a/php72.dockerfile
+++ b/php72.dockerfile
@@ -71,7 +71,6 @@ EXPOSE 80
 
 # Setup container runtime
 COPY scripts/entrypoint.sh /sbin/entrypoint.sh
-COPY scripts/export_secrets.sh /sbin/export_secrets
 COPY scripts/optimize_laravel.sh /sbin/optimize_laravel
 COPY configs/supervisord.conf /etc/supervisord.conf
 RUN sed -i "s|{{php_version}}|${PHP_VERSION}|g" /etc/supervisord.conf


### PR DESCRIPTION
- php72.dockerfile contains copy directive for previously removed export_secrets.sh
- new builds fail without this change