### PR TITLE
Removed chmod of missing file

### DIFF
--- a/php71.dockerfile
+++ b/php71.dockerfile
@@ -76,7 +76,6 @@ COPY configs/supervisord.conf /etc/supervisord.conf
 RUN sed -i "s|{{php_version}}|${PHP_VERSION}|g" /etc/supervisord.conf
 COPY scripts/supervisord-watchdog /sbin/supervisord-watchdog
 RUN chmod 755 /sbin/entrypoint.sh && \
-    chmod 755 /sbin/export_secrets && \
     chmod 755 /sbin/optimize_laravel && \
     chmod 755 /sbin/supervisord-watchdog && \
     touch /var/run/supervisord.pid && \


### PR DESCRIPTION
Docker build for PHP 7.1 was failing because it was referencing a file that was deleted in a previous PR. This fixed that build by removing the unneeded `chmod` on said file.